### PR TITLE
Add support for Sword & Shield DLC Pokémon

### DIFF
--- a/js/names.js
+++ b/js/names.js
@@ -7155,4 +7155,68 @@ window.pokemonNames = [{
     ja: "ムゲンダイナ"
   },
   number: 890,
+},{
+  names: {
+    de: "dakuma",
+    en: "kubfu",
+    fr: "wushours",
+    ja: "ダクマ"
+  },
+  number: 891,
+},{
+  names: {
+    de: "wulaosu",
+    en: "urshifu",
+    fr: "shifours",
+    ja: "ウーラオス"
+  },
+  number: 892,
+},{
+  names: {
+    de: "zarude",
+    en: "zarude",
+    fr: "zarude",
+    ja: "ザルード"
+  },
+  number: 893,
+},{
+  names: {
+    de: "regieleki",
+    en: "regieleki",
+    fr: "regieleki",
+    ja: "レジエレキ"
+  },
+  number: 894,
+},{
+  names: {
+    de: "regidrago",
+    en: "regidrago",
+    fr: "regidrago",
+    ja: "レジドラゴ"
+  },
+  number: 895,
+},{
+  names: {
+    de: "polaross",
+    en: "glastrier",
+    fr: "blizzeval",
+    ja: "ブリザポス"
+  },
+  number: 896,
+},{
+  names: {
+    de: "phantoross",
+    en: "spectrier",
+    fr: "spectreval",
+    ja: "レイスポス"
+  },
+  number: 897,
+},{
+  names: {
+    de: "coronospa",
+    en: "calyrex",
+    fr: "sylveroy",
+    ja: "バドレックス"
+  },
+  number: 898,
 }];

--- a/js/pokemon.js
+++ b/js/pokemon.js
@@ -66,7 +66,7 @@ var allGenerations = {
         // Technically gen 8 starts at 810, but 808 and 809 don't have sprites, and so are closer to being gen 8
         // than gen 7 (they were introduced in Let's Go)
         start: 808,
-        end: 890,
+        end: 898,
         supportedDifficulties: [DIFFICULTY.NORMAL, DIFFICULTY.ELITE, DIFFICULTY.EASY],
     },
 };


### PR DESCRIPTION
Hello! First, I'd like to say I love the idea behind this project -- as someone who's memorized a lot of Pokémon cries over the years, it's pretty fun to challenge myself every once in a while and see how well I can remember them all.

This pull request does as the title suggests, adds support for the new Pokémon introduced in The Isle of Armor and The Crown Tundra from the Sword & Shield Expansion Passes.

As an aside, Meltan and Melmetal currently have their cries missing, and the Generation VIII cries are low quality, Poké Ball Plus versions that are very inconsistent with the remaining 807 cries. Since media isn't stored in the main repository, if you'd like and provide the means to contact you (preferably Twitter/email), I can send you the required assets to get them ready for the website (this includes artwork and cries). I've dumped them directly from the games myself and would be happy to contribute!

I've already got everything running perfectly locally:
![image](https://user-images.githubusercontent.com/17801814/101092220-4c2ff300-3587-11eb-96ab-7c0cd3003233.png)