### PR TITLE
Add support for Pokémon Legends: Arceus data

### DIFF
--- a/js/names.js
+++ b/js/names.js
@@ -7219,4 +7219,60 @@ window.pokemonNames = [{
     ja: "バドレックス"
   },
   number: 898,
+},{
+  names: {
+    de: "damythir",
+    en: "wyrdeer",
+    fr: "cerbyllin",
+    ja: "アヤシシ"
+  },
+  number: 899,
+},{
+  names: {
+    de: "axantor",
+    en: "kleavor",
+    fr: "hachécateur",
+    ja: "バサギリ"
+  },
+  number: 900,
+},{
+  names: {
+    de: "ursaluna",
+    en: "ursaluna",
+    fr: "ursaking",
+    ja: "ガチグマ"
+  },
+  number: 901,
+},{
+  names: {
+    de: "salmagnis",
+    en: "basculegion",
+    fr: "paragruel",
+    ja: "イダイトウ"
+  },
+  number: 902,
+},{
+  names: {
+    de: "snieboss",
+    en: "sneasler",
+    fr: "farfurex",
+    ja: "オオニューラ"
+  },
+  number: 903,
+},{
+  names: {
+    de: "myriador",
+    en: "overqwil",
+    fr: "qwilpik",
+    ja: "ハリーマン"
+  },
+  number: 904,
+},{
+  names: {
+    de: "cupidos",
+    en: "enamorus",
+    fr: "amovénus",
+    ja: "ラブトロス"
+  },
+  number: 905,
 }];

--- a/js/pokemon.js
+++ b/js/pokemon.js
@@ -66,7 +66,7 @@ var allGenerations = {
         // Technically gen 8 starts at 810, but 808 and 809 don't have sprites, and so are closer to being gen 8
         // than gen 7 (they were introduced in Let's Go)
         start: 808,
-        end: 898,
+        end: 905,
         supportedDifficulties: [DIFFICULTY.NORMAL, DIFFICULTY.ELITE, DIFFICULTY.EASY],
     },
 };


### PR DESCRIPTION
Hello again! Hope you've been doing well lately.

Like with my previous pull request for adding support for DLC Pokémon from Sword & Shield, this pull request adds support for all the brand new species in Legends: Arceus (899 through 905). Linked below is your preferred method of file sharing from last time.

Cry data and artwork: https://we.tl/t-q5gxGxchqg

The zip file contains official artwork for Wyrdeer, Kleavor, and Basculegion. Those without public official artwork yet use their Pokédex renders dumped from the game (this can be updated in the future). Also note that this zip includes updated cry data for Pikachu and Eevee. The former received a brand new cry akin to its cry from Generations 1 through 5, and the latter is simply there so that audio levels are in sync with other cry data (3DS vs Switch).

If you need anything more, please feel free to reach out before merging!