### PR TITLE
Media Updates - July 2022

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
 			<h1 class="mobile translatable" data-lang="settings">Settings</h1>
 			<h2 id="genHeader" class="sectionHead translatable" data-lang="generation">Generation</h2>
 			<div id="genSelectContainer" class="sidebox userChoice">
-				<a id="gen1" data-gen="1" title="Red, Blue &amp; Yellow" class="genSelect translatable" data-lang="generation-1">Gen 1</a>
-				<a id="gen2" data-gen="2" title="Gold, Silver &amp; Crystal" class="genSelect translatable" data-lang="generation-2">Gen 2</a>
-				<a id="gen3" data-gen="3" title="Ruby, Sapphire &amp; Emerald" class="genSelect translatable" data-lang="generation-3">Gen 3</a>
-				<a id="gen4" data-gen="4" title="Diamond, Pearl &amp; Platinum" class="genSelect translatable" data-lang="generation-4">Gen 4</a>
+				<a id="gen1" data-gen="1" title="Red, Blue, &amp; Yellow" class="genSelect translatable" data-lang="generation-1">Gen 1</a>
+				<a id="gen2" data-gen="2" title="Gold, Silver, &amp; Crystal" class="genSelect translatable" data-lang="generation-2">Gen 2</a>
+				<a id="gen3" data-gen="3" title="Ruby, Sapphire, &amp; Emerald" class="genSelect translatable" data-lang="generation-3">Gen 3</a>
+				<a id="gen4" data-gen="4" title="Diamond, Pearl, &amp; Platinum" class="genSelect translatable" data-lang="generation-4">Gen 4</a>
 				<a id="gen5" data-gen="5" title="Black &amp; White" class="genSelect translatable" data-lang="generation-5">Gen 5</a>
 				<a id="gen6" data-gen="6" title="X &amp; Y" class="genSelect translatable" data-lang="generation-6">Gen 6</a>
-				<a id="gen7" data-gen="7" title="Sun &amp; Moon" class="genSelect translatable" data-lang="generation-7">Gen 7</a>
-				<a id="gen8" data-gen="8" title="Sword &amp; Shield" class="genSelect translatable" data-lang="generation-8">Gen 8</a>
+				<a id="gen7" data-gen="7" title="Sun, Moon, Ultra Sun, &amp; Ultra Moon" class="genSelect translatable" data-lang="generation-7">Gen 7</a>
+				<a id="gen8" data-gen="8" title="Let's Go, Sword, Shield, &amp; Legends: Arceus" class="genSelect translatable" data-lang="generation-8">Gen 8</a>
 			</div>
 
 			<h2 id="difficultyHeader" class="sectionHead translatable" data-lang="difficulty">Difficulty</h2>


### PR DESCRIPTION
Hello again! I've been looking back at the project these last few days, and have some updates to share with you.

Presented changes:
* `index.html` - Update `genSelectContainer` for slight grammar fixes, and label more games where appropriate.
* Media (images and sounds) - some new updates from me! A more in-depth list is below.

Images:
* Add official Ken Sugimori artwork for Ursaluna, Sneasler, Overqwil, and Incarnate Forme Enamorus
* Revise artwork for Unfezant, Frillish, Jellicent, and Basculegion to display both genders - this is already done with Pyroar, Meowstic, and Indeedee, so wanted to remain consistent wherever possible

Sounds:
* Better MP3 compression
* Fix an issue where Ferroseed still had Venipede's cry (resolves #22)
* Fix an issue where Gulpin's cry was erroneously Makuhita's

For posterity, I've double-checked all of the cry data, and can verify accuracy and no regressions with the site when running locally on my machine. My proposed changes for images and sounds can be [downloaded here](https://mega.nz/file/RZ1jUBKA#Odq_yjWzXgjDa4t7rlkq-_cCM_YqeKQuuY3J0OntI8M).

P.S. I plan on reaching out to you again when Scarlet and Violet are released, to hopefully have support for Generation 9 as soon as possible! I recently wrote a LINQPad script that uses PKHeX.Core to generate arrays of species name translations for use with the project (it can be found [here](https://pastebin.com/x8Y84UVi) on my Pastebin), so it will make future additions much more streamlined.