### PR TITLE
Improved tabbing behaviour

### DIFF
--- a/src/components/AnswerInput.tsx
+++ b/src/components/AnswerInput.tsx
@@ -70,9 +70,9 @@ const AnswerInput = () => {
     }
   };
 
-  const onGiveUp = () => {
-    if (isInputRecentlyFocused) {
-      inputRef.current?.focus(); // re-focus the input if this button press blurred it
+  const onGiveUp = (forceFocus: boolean) => {
+    if (isInputRecentlyFocused || forceFocus) {
+      inputRef.current?.focus(); // re-focus the input if this button press blurred it, or the give up button was triggered via enter/space
     }
 
     dispatch(revealPokemon({ isCorrect: false }));
@@ -135,7 +135,8 @@ const AnswerInput = () => {
         <button
           tabIndex={2}
           className="dont-know-button"
-          onClick={onGiveUp}
+          onClick={() => onGiveUp(false)}
+          onKeyDown={(event) => (event.key === 'Enter' || event.key === ' ') && onGiveUp(true)}
         >
           {lang.dontknow}
         </button>

--- a/src/components/AnswerInput.tsx
+++ b/src/components/AnswerInput.tsx
@@ -133,6 +133,7 @@ const AnswerInput = () => {
         </div>
       ) : (
         <button
+          tabIndex={2}
           className="dont-know-button"
           onClick={onGiveUp}
         >

--- a/src/components/StatsModal.tsx
+++ b/src/components/StatsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'preact/hooks';
+import { useCallback, useEffect, useMemo } from 'preact/hooks';
 import type { JSXInternal } from 'preact/src/jsx';
 
 import { POKEMON_NAMES } from '../constants/pokemon';
@@ -22,6 +22,17 @@ const StatsModal = ({ onClose }: StatsModalProps) => {
   const lang = useLang();
   const settings = useSettings();
   const stats = useStats();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   const tableData = useMemo(() => {
     const sortSign = stats.tableSort.ascending ? -1 : 1;

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,21 @@
 :root {
   --color-background: #d7dbdd;
   --color-box-background: rgba(255, 255, 255, 0.25);
+  --color-focused-outline: #d96659;
   --color-side-box: #34495e;
+  --color-side-box-focused-background: rgba(255, 255, 255, 0.07);;
   --color-side-box-selected: #fff;
+  --color-side-box-selected-focused-background: #fff5f5;
   --color-side-box-faded: #9dbbd9;
+  --color-input-focused-outline: #fff;
+  --color-input-focused-background: rgba(255, 255, 255, 0.1);
   --color-primary: #3498db;
   --color-text: #333;
   --color-text-contrast: #fff;
   --color-text-muted: #666;
+  --color-text-muted-shadow: #e1e1e1;
   --color-positive: #27ae60;
   --color-negative: #c0392b;
-  --color-negative-focused: #d96659;
   --color-modal-content: #fff;
   --font-family: 'Cantora One', sans-serif;
 }
@@ -60,7 +65,7 @@ button {
 }
 
 a:focus-visible, button:focus-visible {
-    outline: 2px solid var(--color-negative-focused);
+    outline: 2px solid var(--color-focused-outline);
     z-index: 2;
     border-radius: 3px;
 }
@@ -163,8 +168,8 @@ ul {
 }
 
 .menu-section button:focus-visible {
-  background-color: #ffffff14;
-  outline-color: var(--color-negative-focused);
+  background-color: var(--color-side-box-focused-background);
+  outline-color: var(--color-focused-outline);
 }
 
 .menu-section button.selected {
@@ -173,8 +178,8 @@ ul {
 }
 
 .menu-section button.selected:focus-visible {
-  background-color: #fff5f5;
-  outline-color: var(--color-negative-focused);
+  background-color: var(--color-side-box-selected-focused-background);
+  outline-color: var(--color-focused-outline);
 }
 
 .menu-section button.pending {
@@ -382,8 +387,8 @@ header button {
 }
 
 .dont-know-button:focus-visible {
-  outline-color: #ffffff;
-  background-color: rgba(255, 255, 255, 0.103);
+  outline-color: var(--color-input-focused-outline);
+  background-color: var(--color-input-focused-background);
 }
 
 .also-known-as h2 {
@@ -442,7 +447,7 @@ footer {
   font-size: 75%;
   margin: 1em;
   text-align: center;
-  text-shadow: 1px 1px #e1e1e1;
+  text-shadow: 1px 1px var(--color-text-muted-shadow);
 }
 
 footer a {

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   --color-text-muted: #666;
   --color-positive: #27ae60;
   --color-negative: #c0392b;
+  --color-negative-focused: #d96659;
   --color-modal-content: #fff;
   --font-family: 'Cantora One', sans-serif;
 }
@@ -56,6 +57,12 @@ button {
   font-family: var(--font-family);
   color: var(--color-text-contrast);
   cursor: pointer;
+}
+
+a:focus-visible, button:focus-visible {
+    outline: 2px solid var(--color-negative-focused);
+    z-index: 2;
+    border-radius: 3px;
 }
 
 h1, h2, h3 {
@@ -155,9 +162,19 @@ ul {
   color: var(--color-side-box-faded);
 }
 
+.menu-section button:focus-visible {
+  background-color: #ffffff14;
+  outline-color: var(--color-negative-focused);
+}
+
 .menu-section button.selected {
   background-color: var(--color-side-box-selected);
   color: var(--color-side-box);
+}
+
+.menu-section button.selected:focus-visible {
+  background-color: #fff5f5;
+  outline-color: var(--color-negative-focused);
 }
 
 .menu-section button.pending {
@@ -298,7 +315,7 @@ header button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
 }
 
 .answer-input-container {
@@ -361,6 +378,12 @@ header button {
 .dont-know-button {
   text-shadow: 1px 1px var(--color-negative);
   font-size: 120%;
+  padding: 1px 8px;
+}
+
+.dont-know-button:focus-visible {
+  outline-color: #ffffff;
+  background-color: rgba(255, 255, 255, 0.103);
 }
 
 .also-known-as h2 {


### PR DESCRIPTION
I think it would be best not to alter the behaviour of the tab key, as users may depend on it for a11y. Instead I:

- Improved the visibility of the tabbed elements, giving them outlines and subtle backgrounds
- Made the don't know button the next tab-index after input so that getting to don't know is easier
- Forced focus on input after dont-know is triggered by a key press. This maintains the current behaviour of dont-know for clicking while also making it so users don't need to trigger dont-know within 200ms of tabbing to regain focus.